### PR TITLE
fix name and message in profile and otherUserProfile

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -76,7 +76,7 @@
       "creationDate": "Creation date:",
       "updateDate": "Last update date:",
       "logout": "Logout",
-      "yourName": "Your name:",
+      "yourName": "Name not specified",
       "profilePageUpdatedSuccessfully": "Profile page updated successfully!",
       "subscribe": "Subscribe",
       "unsubscribe": "Unsubscribe",

--- a/frontend/public/locales/ua/translation.json
+++ b/frontend/public/locales/ua/translation.json
@@ -76,7 +76,7 @@
       "creationDate": "Дата створення:",
       "updateDate": "Дата останнього оновлення:",
       "logout": "Вийти",
-      "yourName": "Ваше ім'я:",
+      "yourName": "Ім'я не вказано",
       "profilePageUpdatedSuccessfully": "Дані профілю успішно оновлені!",
       "subscribe": "Підписатись",
       "unsubscribe": "Відписатись",

--- a/frontend/src/components/BigPopup/CommentSection/CommentSection.tsx
+++ b/frontend/src/components/BigPopup/CommentSection/CommentSection.tsx
@@ -36,7 +36,6 @@ const CommentSection = () => {
 
   const myRole = useTypedSelector(selectUserRole);
 
-
   const { fetchComments } = useTypedDispatch();
 
   const topComments = comments.filter(

--- a/frontend/src/screens/PersonProfile/PersonProfilePage.tsx
+++ b/frontend/src/screens/PersonProfile/PersonProfilePage.tsx
@@ -101,7 +101,7 @@ export default function PersonProfilePage() {
           src={userAvatar || userImageNotFound}
         />
         <Typography mt={2} variant="h5" component="h4" align="center">
-          {displayName ? `${t('profile.profilePage.yourName')}` : displayName}
+          {!displayName ? `${t('profile.profilePage.yourName')}` : displayName}
         </Typography>
 
         {isAuthorized && (

--- a/frontend/src/screens/Profile/ProfilePage.tsx
+++ b/frontend/src/screens/Profile/ProfilePage.tsx
@@ -155,7 +155,7 @@ export default function ProfilePage() {
                 />
               </StyledProfileBadge>
               <Typography mt={2} variant="h5" component="h4" align="center">
-                {displayName
+                {!displayName
                   ? `${t('profile.profilePage.yourName')}`
                   : displayName}
               </Typography>


### PR DESCRIPTION
Fixed name and message in profile and otherUserProfile.
Changed message, if user name  not specified show message "Name not specified" ("Ім'я не вказано")
![image](https://user-images.githubusercontent.com/37217530/179491091-97ec9d96-95c0-44ca-91a7-8595fccc63be.png)

early we displayed message "Your name: "
![image](https://user-images.githubusercontent.com/37217530/179491809-e7f40e97-2733-4caf-8462-aac9df282457.png)
